### PR TITLE
Fix double/triple etc messages on rejoin

### DIFF
--- a/src/client/java/me/omrih/legitimooseBot/client/LegitimooseBotClient.java
+++ b/src/client/java/me/omrih/legitimooseBot/client/LegitimooseBotClient.java
@@ -26,6 +26,7 @@ public class LegitimooseBotClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        new Thread(DiscordMessageListener::main).start();
         ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> ScrapeCommand.registerCommand(dispatcher));
 
         ScreenEvents.AFTER_INIT.register((minecraftClient, screen, i, i1) -> {
@@ -69,7 +70,6 @@ public class LegitimooseBotClient implements ClientModInitializer {
                     }
                 }
             }).start();
-            new Thread(DiscordMessageListener::main).start();
         });
 
         ClientReceiveMessageEvents.GAME.register((message, overlay) -> {


### PR DESCRIPTION
should have done it this way in the first place

Fixes #31 