### PR TITLE
Surrounded MSG message content in ` `

### DIFF
--- a/src/client/java/me/omrih/legitimooseBot/client/discord/DiscordBot.java
+++ b/src/client/java/me/omrih/legitimooseBot/client/discord/DiscordBot.java
@@ -90,7 +90,7 @@ public class DiscordBot extends ListenerAdapter {
             });
         } else if (event.getName().equals("msg")) {
             MinecraftClient.getInstance().player.networkHandler.sendChatCommand("msg " + event.getOption("player").getAsString() + " [ᴅɪsᴄᴏʀᴅ] " + event.getMember().getEffectiveName() + ": " + event.getOption("message").getAsString().replace("\n", "<br>").replace("§", "?"));
-            event.reply("Sent " + event.getOption("message").getAsString().trim() + " to " + event.getOption("player").getAsString()).setEphemeral(true).queue();
+            event.reply("Sent `" + event.getOption("message").getAsString().trim() + "` to " + event.getOption("player").getAsString()).setEphemeral(true).queue();
         }
     }
 


### PR DESCRIPTION
I had made a suggestion in the discord to do this, and decided, _i'll just do this myself_ so i did that, the format for a msg is Sent `<message>` to <user>
![image](https://github.com/user-attachments/assets/f91e1b37-8cd7-4fa0-a81f-8afd0f9ab177)
