### PR TITLE
New discord commands for preventing players using the bot

### DIFF
--- a/src/client/java/net/legitimoose/bot/LegitimooseBotClient.java
+++ b/src/client/java/net/legitimoose/bot/LegitimooseBotClient.java
@@ -9,6 +9,7 @@ import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.legitimoose.bot.chat.GameChatHandler;
 import net.legitimoose.bot.discord.DiscordBot;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.http.HttpServer;
 import net.legitimoose.bot.scraper.Scraper;
 import net.minecraft.client.Minecraft;
@@ -58,7 +59,7 @@ public class LegitimooseBotClient implements ClientModInitializer {
 
         ClientTickEvents.END_CLIENT_TICK.register((minecraft) -> attemptRejoin(false));
 
-        schedulePeriodicalMessage();
+        schedulePeriodicalEvents();
 
         ClientReceiveMessageEvents.GAME.register((message, overlay) -> {
             threadPool.execute(() -> GameChatHandler.getInstance().handleChat(message));
@@ -82,7 +83,7 @@ public class LegitimooseBotClient implements ClientModInitializer {
         }, TWENTY_FOUR_HOURS, TWENTY_FOUR_HOURS);
     }
 
-    private void schedulePeriodicalMessage() {
+    private void schedulePeriodicalEvents() {
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 
         scheduler.scheduleAtFixedRate(() -> {
@@ -92,6 +93,13 @@ public class LegitimooseBotClient implements ClientModInitializer {
                 player.connection.sendChat(MESSAGE);
             }
         }, 0, 20, TimeUnit.MINUTES);
+
+        // Mutes may take an extra 20s to be retracted but that is no problem
+        // Could calculate relative time and subtract 0-20s from each mute when
+        // given to make time exact, would need to store extra stuff too. Not worth the effort
+        scheduler.scheduleAtFixedRate(() -> {
+            BotMuteHandler.getInstance().refresh();
+        }, 0, 20, TimeUnit.SECONDS);
     }
 
     private void registerCommands() {

--- a/src/client/java/net/legitimoose/bot/chat/GameChatHandler.java
+++ b/src/client/java/net/legitimoose/bot/chat/GameChatHandler.java
@@ -10,6 +10,7 @@ import net.legitimoose.bot.chat.matcher.*;
 import net.legitimoose.bot.discord.DiscordBot;
 import net.legitimoose.bot.discord.command.MsgCommand;
 import net.legitimoose.bot.discord.command.ReplyCommand;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.scraper.*;
 import net.legitimoose.bot.util.DiscordUtil;
 import net.legitimoose.bot.util.DiscordWebhook;
@@ -134,6 +135,9 @@ public class GameChatHandler {
 
     public void handleMsgMessage(MsgMatcher msg) {
         String senderUsername = msg.getSenderUsername();
+        if (BotMuteHandler.getInstance().shouldCancelPlayer(senderUsername, true)) {
+            return;
+        }
         String discordReceiverName = msg.getDiscordReceiver();
         String message = msg.getMessage();
         User user;
@@ -155,6 +159,8 @@ public class GameChatHandler {
      * Handles a bot command sent by a user. See {@link #handleChatMessage}.
      */
     private void handleCommandMessage(String command, String senderUsername) {
+        if (BotMuteHandler.getInstance().shouldCancelPlayer(senderUsername, false))
+            return;
         try {
             dispatcher.execute(command, new CommandSource(senderUsername));
         } catch (CommandSyntaxException e) {

--- a/src/client/java/net/legitimoose/bot/discord/DiscordBot.java
+++ b/src/client/java/net/legitimoose/bot/discord/DiscordBot.java
@@ -16,9 +16,7 @@ import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.legitimoose.bot.discord.command.*;
-import net.legitimoose.bot.discord.command.staff.Rejoin;
-import net.legitimoose.bot.discord.command.staff.Restart;
-import net.legitimoose.bot.discord.command.staff.Send;
+import net.legitimoose.bot.discord.command.staff.*;
 import net.legitimoose.bot.util.McUtil;
 import net.minecraft.client.Minecraft;
 
@@ -42,7 +40,10 @@ public class DiscordBot extends ListenerAdapter {
 
                 new Restart(),
                 new Rejoin(),
-                new Send()
+                new Send(),
+                new Mute(),
+                new UnMute(),
+                new MuteList()
         );
         jda = JDABuilder.createDefault(CONFIG.getString("token"))
                 .enableIntents(GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
@@ -92,7 +93,8 @@ public class DiscordBot extends ListenerAdapter {
                                         new SubcommandData("player", "Get a player's streak")
                                                 .addOption(OptionType.STRING, "player", "The player whose streak you want to check", true),
                                         new SubcommandData("lb", "Leaderboard")
-                                ))
+                                )
+                )
                 .queue();
     }
 
@@ -111,7 +113,24 @@ public class DiscordBot extends ListenerAdapter {
                         Commands.slash("send", "Send message")
                                 .setDefaultPermissions(
                                         DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER))
-                                .addOption(OptionType.STRING, "message", "The message to send", true))
+                                .addOption(OptionType.STRING, "message", "The message to send", true),
+                        Commands.slash("botmute", "Stop a player from using the bot")
+                                .addOption(OptionType.USER, "discord_id", "The discord ID of the player", true)
+                                .addOption(OptionType.STRING, "minecraft_name", "The minecraft username of the player", true)
+                                .addOption(OptionType.STRING, "duration", "The length of the punishment", true)
+                                .addOption(OptionType.STRING, "reason", "The reason for this punishment", true)
+                                .setDefaultPermissions(
+                                        DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER)),
+                        Commands.slash("unbotmute", "Take back a bot mute")
+                                .addOption(OptionType.USER, "discord_id", "The discord ID of the player", true)
+                                .addOption(OptionType.STRING, "minecraft_name", "The minecraft name of the player", true)
+                                .setDefaultPermissions(
+                                        DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER)),
+                        Commands.slash("botmutelist", "See all bot mutes")
+                                .setDefaultPermissions(
+                                        DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER))
+                                .addOption(OptionType.INTEGER, "page", "The page to display", false)
+                )
                 .queue();
     }
 

--- a/src/client/java/net/legitimoose/bot/discord/command/FindCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/FindCommand.java
@@ -3,6 +3,7 @@ package net.legitimoose.bot.discord.command;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.legitimoose.bot.chat.GameChatHandler;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.util.DiscordUtil;
 import net.legitimoose.bot.util.McUtil;
 import net.minecraft.client.Minecraft;
@@ -15,6 +16,11 @@ public class FindCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("find")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
+
         String player = event.getOption("player").getAsString();
         if (player.length() >= 200) {
             event.reply("player name too long, sorry!").setEphemeral(true).queue();

--- a/src/client/java/net/legitimoose/bot/discord/command/ListCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/ListCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.suggestion.Suggestions;
 import com.mongodb.client.MongoCollection;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.scraper.Scraper;
 import net.legitimoose.bot.util.DiscordUtil;
 import net.minecraft.client.Minecraft;
@@ -24,6 +25,11 @@ public class ListCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("list")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
+
         switch (event.getSubcommandName()) {
             case "lobby" -> {
                 Collection<PlayerInfo> playerList =

--- a/src/client/java/net/legitimoose/bot/discord/command/ListallCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/ListallCommand.java
@@ -2,6 +2,7 @@ package net.legitimoose.bot.discord.command;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.http.endpoint.PlayersEndpoint;
 import net.legitimoose.bot.util.DiscordUtil;
 
@@ -9,6 +10,10 @@ public class ListallCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("listall")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
 
         boolean raw;
         if (event.getOption("raw") != null) {

--- a/src/client/java/net/legitimoose/bot/discord/command/MsgCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/MsgCommand.java
@@ -2,6 +2,7 @@ package net.legitimoose.bot.discord.command;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.scraper.Database;
 import net.legitimoose.bot.scraper.Player;
 import net.legitimoose.bot.util.DiscordUtil;
@@ -20,6 +21,11 @@ public class MsgCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("msg")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
+
         String message = event.getOption("message").getAsString();
         String player = event.getOption("player").getAsString();
         Player playerObj = Database.getPlayers().find(regex("name", player, "i")).first();

--- a/src/client/java/net/legitimoose/bot/discord/command/ReplyCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/ReplyCommand.java
@@ -2,6 +2,7 @@ package net.legitimoose.bot.discord.command;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.util.DiscordUtil;
 import net.legitimoose.bot.util.McUtil;
 import net.minecraft.client.Minecraft;
@@ -15,6 +16,11 @@ public class ReplyCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("reply")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
+
         String message = event.getOption("message").getAsString();
         if (lastSentReply.get(event.getUser().getIdLong()) == null) {
             event.reply("You have no incoming messages to reply.").setEphemeral(true).queue();

--- a/src/client/java/net/legitimoose/bot/discord/command/ShoutCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/ShoutCommand.java
@@ -3,6 +3,7 @@ package net.legitimoose.bot.discord.command;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.util.DiscordUtil;
 import net.legitimoose.bot.util.McUtil;
 import net.minecraft.client.Minecraft;
@@ -19,6 +20,11 @@ public class ShoutCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("shout")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
+
         String message = event.getOption("message").getAsString();
         long userId = event.getUser().getIdLong();
         Long lastUsed = cooldown.get(userId);

--- a/src/client/java/net/legitimoose/bot/discord/command/StreakCommand.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/StreakCommand.java
@@ -3,6 +3,7 @@ package net.legitimoose.bot.discord.command;
 import com.mongodb.client.model.Filters;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
 import net.legitimoose.bot.scraper.Database;
 import net.legitimoose.bot.scraper.Player;
 
@@ -11,6 +12,11 @@ public class StreakCommand extends ListenerAdapter {
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (!event.getName().equals("streak")) return;
+
+        if (BotMuteHandler.getInstance().shouldCancelCommand(event)) {
+            return;
+        }
+
         switch (event.getSubcommandName()) {
             case "player" -> {
                 String player = event.getOption("player").getAsString();

--- a/src/client/java/net/legitimoose/bot/discord/command/mute/BotMute.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/mute/BotMute.java
@@ -1,0 +1,18 @@
+package net.legitimoose.bot.discord.command.mute;
+
+import net.legitimoose.bot.util.TimeUtil;
+
+public record BotMute(String minecraft_name, String discord_id, long end_time, String reason) {
+
+    @Override
+    public String toString() {
+        String prefix = "<@" + discord_id + "> | " + minecraft_name + " for " + reason;
+        String time = hasExpired() ? "0s" : TimeUtil.format(end_time - System.currentTimeMillis());
+        return prefix + " expires in " + time;
+    }
+
+    public boolean hasExpired() {
+        return end_time < System.currentTimeMillis();
+    }
+
+}

--- a/src/client/java/net/legitimoose/bot/discord/command/mute/BotMuteHandler.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/mute/BotMuteHandler.java
@@ -1,0 +1,114 @@
+package net.legitimoose.bot.discord.command.mute;
+
+import com.mongodb.client.model.Filters;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.legitimoose.bot.scraper.Database;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import org.bson.conversions.Bson;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BotMuteHandler {
+
+    private static final String MUTED_MESSAGE = "You are not able to use the bot";
+
+    private static BotMuteHandler instance;
+
+    /**
+     * Runtime sets for faster lookup
+     */
+    private final Set<String> discordIds, minecraftNames;
+
+    private BotMuteHandler() {
+        discordIds = new HashSet<>();
+        minecraftNames = new HashSet<>();
+
+        // Store all mutes in the sets
+        for (BotMute mute : Database.getBotMutes().find()) {
+            discordIds.add(mute.discord_id());
+            minecraftNames.add(mute.minecraft_name());
+        }
+    }
+
+    public static BotMuteHandler getInstance() {
+        return instance == null ? (instance = new BotMuteHandler()) : instance;
+    }
+
+    public void add(BotMute mute) {
+        Database.getBotMutes().insertOne(mute);
+        minecraftNames.add(mute.minecraft_name());
+        discordIds.add(mute.discord_id());
+    }
+
+    /**
+     * @return if the deletion was successful
+     */
+    public boolean delete(String discordId, String minecraftName) {
+        minecraftNames.remove(minecraftName);
+        discordIds.remove(discordId);
+        Bson filter = filter(discordId, minecraftName);
+        return Database.getBotMutes().deleteOne(filter).getDeletedCount() > 0;
+    }
+
+    /**
+     * @return whether either the discord ID or minecraft name are marked as muted
+     */
+    public boolean contains(String discordId, String minecraftName) {
+        return discordIds.contains(discordId) || minecraftNames.contains(minecraftName);
+    }
+
+    /**
+     * Removes all expired mutes
+     */
+    public void refresh() {
+        for (BotMute mute : Database.getBotMutes().find()) {
+            if (mute.hasExpired()) {
+                delete(mute.discord_id(), mute.minecraft_name());
+            }
+        }
+    }
+
+    private boolean isMutedIngame(String name) {
+        return minecraftNames.contains(name);
+    }
+
+    private boolean isMutedDiscord(String id) {
+        return discordIds.contains(id);
+    }
+
+    /**
+     * @return whether the player is muted and interaction should be cancelled
+     */
+    public boolean shouldCancelPlayer(String player, boolean privateMessage) {
+        if (isMutedIngame(player)) {
+            ClientPacketListener connection = Minecraft.getInstance().getConnection();
+            if (privateMessage)
+                connection.sendCommand("msg " + player + " " + MUTED_MESSAGE);
+            else
+                connection.sendChat(MUTED_MESSAGE);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return whether the user is muted and event should be cancelled
+     */
+    public boolean shouldCancelCommand(SlashCommandInteractionEvent event) {
+        if (isMutedDiscord(event.getUser().getId())) {
+            event.reply(MUTED_MESSAGE).setEphemeral(true).queue();
+            return true;
+        }
+        return false;
+    }
+
+    private static Bson filter(String discordId, String minecraftName) {
+        return Filters.and(
+                Filters.eq("discord_id", discordId),
+                Filters.eq("minecraft_name", minecraftName)
+        );
+    }
+
+}

--- a/src/client/java/net/legitimoose/bot/discord/command/staff/Mute.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/staff/Mute.java
@@ -1,0 +1,69 @@
+package net.legitimoose.bot.discord.command.staff;
+
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.legitimoose.bot.discord.command.mute.BotMute;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
+import net.legitimoose.bot.util.TimeUtil;
+
+public class Mute extends ListenerAdapter {
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("botmute"))
+            return;
+
+        event.deferReply().queue();
+
+        String timeString = event.getOption("duration").getAsString();
+
+        long endTime = validateDuration(timeString, event.getHook());
+        if (endTime == -1)
+            return;
+
+        User user = event.getOption("discord_id").getAsUser();
+        String minecraftName = event.getOption("minecraft_name").getAsString();
+        String reason = event.getOption("reason").getAsString();
+
+        if (!validateReason(reason, event.getHook()))
+            return;
+
+        if (!validateUser(user.getId(), minecraftName, event.getHook()))
+            return;
+
+        BotMuteHandler.getInstance().add(new BotMute(minecraftName, user.getId(), endTime, reason));
+
+        String notice = "User <@" + user.getId() + "> | " + minecraftName +
+                " has been muted from the bot for " + timeString + " due to " + reason;
+
+        event.getHook().sendMessage(notice).queue();
+    }
+
+    private boolean validateReason(String reason, InteractionHook hook) {
+        if (reason.length() > 50) {
+            hook.sendMessage("Reason is too long, max 50 characters").queue();
+            return false;
+        }
+        return true;
+    }
+
+    private boolean validateUser(String discordId, String minecraftName, InteractionHook hook) {
+        if (BotMuteHandler.getInstance().contains(discordId, minecraftName)) {
+            hook.sendMessage("User is already muted").setEphemeral(true).queue();
+            return false;
+        }
+        return true;
+    }
+
+    private long validateDuration(String duration, InteractionHook hook) {
+        long time = TimeUtil.parse(duration);
+        if (time == -1) {
+            hook.sendMessage("Invalid duration given").setEphemeral(true).queue();
+            return -1;
+        }
+        return time + System.currentTimeMillis();
+    }
+
+}

--- a/src/client/java/net/legitimoose/bot/discord/command/staff/MuteList.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/staff/MuteList.java
@@ -1,0 +1,64 @@
+package net.legitimoose.bot.discord.command.staff;
+
+import com.mongodb.client.FindIterable;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.legitimoose.bot.discord.command.mute.BotMute;
+import net.legitimoose.bot.scraper.Database;
+
+public class MuteList extends ListenerAdapter {
+
+    private static final int MUTES_PER_PAGE = 5;
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("botmutelist"))
+            return;
+
+        event.deferReply(true).queue();
+
+        int page = validatePage(event);
+        if (page == -1)
+            return;
+
+        StringBuilder sb = new StringBuilder();
+        int start = (page - 1) * MUTES_PER_PAGE;
+        int added = 0;
+        int maxLengthPerEntry = Message.MAX_CONTENT_LENGTH / MUTES_PER_PAGE;
+
+        FindIterable<BotMute> mutes = Database.getBotMutes().find().skip(start);
+
+        for (BotMute mute : mutes) {
+            if (added < MUTES_PER_PAGE) {
+                String string = (added + 1 + start) + ". " + mute.toString() + "\n";
+                if (string.length() > maxLengthPerEntry) {
+                    // maxLengthPerEntry - 4 to also remove the newline
+                    sb.append(string, 0, maxLengthPerEntry - 4).append("...\n");
+                } else {
+                    sb.append(string);
+                }
+                added++;
+            }
+        }
+
+        if (added == 0) {
+            String message = start == 0 ? "No users are muted" : "Page " + page + " is empty";
+            event.getHook().sendMessage(message).queue();
+        } else {
+            event.getHook().sendMessage(sb.toString()).queue();
+        }
+    }
+
+    private int validatePage(SlashCommandInteractionEvent event) {
+        OptionMapping option = event.getOption("page");
+        int page = option == null ? 1 : option.getAsInt();
+        if (page < 1) {
+            event.getHook().sendMessage("Invalid page number").setEphemeral(true).queue();
+            return -1;
+        }
+        return page;
+    }
+
+}

--- a/src/client/java/net/legitimoose/bot/discord/command/staff/UnMute.java
+++ b/src/client/java/net/legitimoose/bot/discord/command/staff/UnMute.java
@@ -1,0 +1,28 @@
+package net.legitimoose.bot.discord.command.staff;
+
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.legitimoose.bot.discord.command.mute.BotMuteHandler;
+
+public class UnMute extends ListenerAdapter {
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("unbotmute"))
+            return;
+
+        event.deferReply().queue();
+
+        User user = event.getOption("discord_id").getAsUser();
+        String minecraftName = event.getOption("minecraft_name").getAsString();
+
+        boolean didDelete = BotMuteHandler.getInstance().delete(user.getId(), minecraftName);
+
+        if (!didDelete)
+            event.getHook().sendMessage("No bot mute exists for this person!").setEphemeral(true).queue();
+        else
+            event.getHook().sendMessage("<@" + user.getId() + "> | " + minecraftName + " has been unmuted from the bot").queue();
+    }
+
+}

--- a/src/client/java/net/legitimoose/bot/scraper/Database.java
+++ b/src/client/java/net/legitimoose/bot/scraper/Database.java
@@ -1,10 +1,9 @@
 package net.legitimoose.bot.scraper;
 
 import static net.legitimoose.bot.LegitimooseBot.CONFIG;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
+
+import com.mongodb.client.*;
+import net.legitimoose.bot.discord.command.mute.BotMute;
 import org.bson.Document;
 
 public class Database {
@@ -23,12 +22,14 @@ public class Database {
     private MongoCollection<Player> players;
     private MongoCollection<Document> stats;
     private MongoCollection<Ban> bans;
+    private MongoCollection<BotMute> mutes;
 
     private Database() {
         worlds = database.getCollection("worlds", World.class);
         players = database.getCollection("players", Player.class);
         stats = database.getCollection("stats");
         bans = database.getCollection("bans", Ban.class);
+        mutes = database.getCollection("mutes", BotMute.class);
     }
 
     private static Database getInstance() {
@@ -49,6 +50,10 @@ public class Database {
 
     public static MongoCollection<Ban> getBans() {
         return getInstance().bans;
+    }
+
+    public static MongoCollection<BotMute> getBotMutes() {
+        return getInstance().mutes;
     }
 
 }

--- a/src/client/java/net/legitimoose/bot/util/TimeUtil.java
+++ b/src/client/java/net/legitimoose/bot/util/TimeUtil.java
@@ -1,0 +1,64 @@
+package net.legitimoose.bot.util;
+
+public class TimeUtil {
+
+    public static final long MILLIS_PER_MINUTE = 60 * 1000;
+    public static final long MILLIS_PER_HOUR = 60 * 60 * 1000;
+    public static final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+    public static final long MILLIS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+    /**
+     * Formats the time in millis into a string with the first two largest units
+     * <p>
+     * This does truncate values but that's not too much of a problem
+     */
+    public static String format(long time) {
+        if (time < MILLIS_PER_MINUTE)
+            return time / 1000 + "s";
+        if (time < MILLIS_PER_HOUR)
+            return time / MILLIS_PER_MINUTE + "m " + (time % MILLIS_PER_MINUTE) / 1000 + "s";
+        if (time < MILLIS_PER_DAY)
+            return time / MILLIS_PER_HOUR + "h " + (time % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE + "m";
+        if (time < MILLIS_PER_WEEK)
+            return time / MILLIS_PER_DAY + "d " + (time % MILLIS_PER_DAY) / MILLIS_PER_HOUR + "h";
+        return time / MILLIS_PER_WEEK + "w " + (time % MILLIS_PER_WEEK) / MILLIS_PER_DAY + "d";
+    }
+
+    /**
+     * Converts the time string into milliseconds
+     * Accepts any number of space separated specifiers: s, h, d, w
+     * @return -1 if the input is invalid
+     */
+    public static long parse(String time) {
+        long total = -1;
+        String[] segments = time.split(" +");
+        if (segments.length == 0)
+            return -1;
+
+        for (String part : segments) {
+            int l = part.length();
+            if (l < 2)
+                continue;
+
+            try {
+                int prefix = Integer.parseInt(part.substring(0, l - 1));
+
+                total += switch (part.charAt(l - 1)) {
+                    case 's' -> prefix * 1000L;
+                    case 'm' -> prefix * MILLIS_PER_MINUTE;
+                    case 'h' -> prefix * MILLIS_PER_HOUR;
+                    case 'd' -> prefix * MILLIS_PER_DAY;
+                    case 'w' -> prefix * MILLIS_PER_WEEK;
+                    default -> throw new NumberFormatException();
+                };
+
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+
+        // Returns -1 if all parts are too short
+        return total == -1 ? -1 : total + 1;
+    }
+
+}


### PR DESCRIPTION
Added new discord commands to let you prevent people from using with the bot

Discord commands added:

```
/botmute <discord user> <minecraft name> <time> <reason> 
/unbotmute <discord user> <minecraft name>
/botmutelist <optional page>
```

Each mute requires both a discord user and minecraft name, I could make the discord user optional in the future as currently it has to be a real profile from the server

I've also made a new class called TimeUtil which includes the parser for the time argument. The time argument must be a series of segments with a number prefix and a letter suffix, one of either s, m, h, d or w. There is no ability to give 'permanent' mutes but you _can_ give ones significantly longer than the human lifespan

When a player or user is muted they are not allowed to use any discord bot commands (other than admin ones if they have permissions), they can also not run bot commands ingame or use the bot-discord message feature.

The time between a mute expiration and it actually being removed can be from 0-20 seconds which could also be removed in the future, but it's easier this way

There is also a new collection in the database called 'mutes' which stores them