### PR TITLE
Match for tempbans with durations other than hours

### DIFF
--- a/src/client/java/net/legitimoose/bot/chat/GameChatHandler.java
+++ b/src/client/java/net/legitimoose/bot/chat/GameChatHandler.java
@@ -115,8 +115,10 @@ public class GameChatHandler {
         String moderator = tempBan.getModerator();
         String banned = tempBan.getBanned();
         int hours = tempBan.getHours();
+        String banType = tempBan.getBanType();
         String reason = tempBan.getReason();
-        Embed embed = new Embed(DiscordUtil.sanitizeString(String.format("**%s** was banned by **%s** for **%s** hours", banned, moderator, hours)), 0xF25757);
+        String banTimeString = tempBan.getBanTimeString();
+        Embed embed = new Embed(DiscordUtil.sanitizeString(String.format("**%s** was %s by **%s** for **%s**", banned, banType, moderator, banTimeString)), 0xF25757);
         embed.setDescription(DiscordUtil.sanitizeString(reason));
         webhook.setUsername("Legitimoose Ban");
         executeWebhook(webhook, embed, true);

--- a/src/client/java/net/legitimoose/bot/chat/matcher/TempBanMatcher.java
+++ b/src/client/java/net/legitimoose/bot/chat/matcher/TempBanMatcher.java
@@ -14,10 +14,8 @@ import java.util.regex.Pattern;
  */
 public class TempBanMatcher implements MessageMatcher {
 
-    // private static final Pattern PATTERN = Pattern.compile("^(\\S+)\\s+tempbanned\\s+(\\S+)\\s+for\\s+(.+)\\s+hours\\s+for\\s+'(.+)'");
     private static final Pattern PATTERN = Pattern.compile("(\\w{3,16})\\s((?:temp)(?:\\s?IP-)?banned)\\s(\\w{3,16})\\sfor\\s(\\d*\\s(?:days?|hours?|minutes?|seconds?))(?:\\sfor\\s'(.*)')?");
     
-
     private String moderatorName;
     private String typeString;
     private String bannedName;

--- a/src/client/java/net/legitimoose/bot/chat/matcher/TempBanMatcher.java
+++ b/src/client/java/net/legitimoose/bot/chat/matcher/TempBanMatcher.java
@@ -8,25 +8,28 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Matcher for temporary bans.
+ * Matcher for temporary bans. (including IP bans)
  * <p>
- * These are in the format <code>(moderator) tempbanned (player) for (hours) for (reason)</code>
+ * These are in the format <code>(moderator) temp( IP-)banned (player) for (hours) for (reason)</code>
  */
 public class TempBanMatcher implements MessageMatcher {
 
-    private static final Pattern PATTERN = Pattern.compile("^(\\S+)\\s+tempbanned\\s+(\\S+)\\s+for\\s+(.+)\\s+hours\\s+for\\s+'(.+)'");
+    // private static final Pattern PATTERN = Pattern.compile("^(\\S+)\\s+tempbanned\\s+(\\S+)\\s+for\\s+(.+)\\s+hours\\s+for\\s+'(.+)'");
+    private static final Pattern PATTERN = Pattern.compile("(\\w{3,16})\\s((?:temp)(?:\\s?IP-)?banned)\\s(\\w{3,16})\\sfor\\s(\\d*\\s(?:days?|hours?|minutes?|seconds?))(?:\\sfor\\s'(.*)')?");
+    
 
     private String moderatorName;
-
+    private String typeString;
     private String bannedName;
-
+    private String banTimeString;
     private String reason;
-
     private int hours;
 
     public TempBanMatcher() {
         moderatorName = null;
+        typeString = null;
         bannedName = null;
+        banTimeString = null;
         reason = null;
         hours = 0;
     }
@@ -39,9 +42,19 @@ public class TempBanMatcher implements MessageMatcher {
             return false;
 
         moderatorName = matcher.group(1);
-        bannedName = matcher.group(2);
-        hours = Integer.parseInt(matcher.group(3));
-        reason = matcher.group(4);
+        typeString = matcher.group(2); 
+        bannedName = matcher.group(3);
+        banTimeString = matcher.group(4);
+        if (banTimeString.contains("day")) {
+            hours = Integer.parseInt(banTimeString.replace(" day", "").replace("s", "")) * 24;
+        } else if (banTimeString.contains("hour")) {
+            hours = Integer.parseInt(banTimeString.replace(" hour", "").replace("s", ""));
+        } else if (banTimeString.contains("minute")) {
+            hours = Integer.parseInt(banTimeString.replace(" minute", "").replace("s", "")) / 60;
+        } else {
+            hours = Integer.parseInt(banTimeString.replace(" second", "").replace("s", "")) / 3600;
+        }
+        reason = matcher.group(5); // is fine
 
         return true;
     }
@@ -61,6 +74,14 @@ public class TempBanMatcher implements MessageMatcher {
 
     public String getReason() {
         return reason;
+    }
+    
+    public String getBanType() {
+    	return typeString;
+    }
+    
+    public String getBanTimeString() {
+    	return banTimeString;
     }
 
     public int getHours() {


### PR DESCRIPTION
Changed the regex for temporary bans to match for bans with durations that are not in hours.